### PR TITLE
Add basic support for the Query API

### DIFF
--- a/src/d_tree_sitter/d_tree_sitter.d
+++ b/src/d_tree_sitter/d_tree_sitter.d
@@ -12,6 +12,7 @@ public import tree_visitor;
 public import tree_printer;
 public import node;
 public import other;
+public import query;
 
 // export the libc symbols under libc namespace
 public import libc = libc;

--- a/src/d_tree_sitter/query.d
+++ b/src/d_tree_sitter/query.d
@@ -1,0 +1,120 @@
+module query;
+
+import std.algorithm;
+import std.array;
+import std.conv;
+import std.string;
+import language;
+import node;
+import tree_visitor;
+import other;
+import libc : TSQuery, TSQueryError, TSQueryMatch, TSQueryCursor, TSQueryCapture;
+
+struct QueryCapture {
+  Node node;
+  int index;
+  string name;
+}
+
+struct QueryMatch {
+    uint id;
+    uint pattern_index;
+    QueryCapture[] captures;
+}
+
+struct QueryIterator {
+    import libc : ts_query_cursor_new, ts_query_cursor_delete,
+           ts_query_cursor_exec, ts_query_cursor_next_match;
+    Query* query;
+    Node* node;
+
+    private TSQueryCursor* cursor;
+    private TSQueryMatch* match;
+
+    @disable this(this);
+
+    this(Query* query, Node* node) {
+        this.query = query;
+        this.node = node;
+        cursor = ts_query_cursor_new();
+        ts_query_cursor_exec(cursor, query.tsquery, node.tsnode);
+    }
+
+    ~this() {
+        ts_query_cursor_delete(cursor);
+    }
+
+    int opApply(scope int delegate(QueryMatch) dg) {
+        TSQueryMatch match;
+        int result = 0;
+        while(ts_query_cursor_next_match(cursor, &match)) {
+            auto captures = match
+                .captures[0..match.capture_count]
+                .map!((capture) =>
+                    QueryCapture(
+                        Node(capture.node),
+                        capture.index,
+                        query.captureName(capture)
+                    )
+                ).array;
+            result = dg(QueryMatch(match.id, match.pattern_index, captures));
+            if (result)
+                break;
+        }
+        return result;
+    }
+}
+
+class QueryException : Exception {
+    TSQueryError error;
+    this(TSQueryError error) {
+        super("QueryException: " ~ error.to!string);
+        this.error = error;
+    }
+}
+
+struct Query {
+    import libc : ts_query_new, ts_query_delete;
+
+    TSQuery* tsquery;
+    Language language;
+
+    @disable this(this);
+
+    this(Language language, string queryString) {
+        import std.conv;
+        this.language = language;
+        uint errOffset = 0;
+        TSQueryError errType;
+        this.tsquery = ts_query_new(
+            language.tslanguage,
+            queryString.toStringz,
+            queryString.length.to!uint,
+            &errOffset,
+            &errType
+        );
+
+        if(errOffset != 0) {
+            throw new QueryException(errType);
+        }
+    }
+
+    ~this() {
+        ts_query_delete(tsquery);
+    }
+
+    QueryIterator exec(Node node) {
+        return QueryIterator(&this, &node);
+    }
+
+    string captureName(TSQueryCapture capture) {
+        import libc : ts_query_capture_name_for_id;
+        uint length;
+        auto namePtr = ts_query_capture_name_for_id(
+            tsquery,
+            capture.index,
+            &length
+        );
+        return namePtr[0..length].to!string;
+    }
+}

--- a/src/d_tree_sitter/query.d
+++ b/src/d_tree_sitter/query.d
@@ -50,13 +50,13 @@ struct QueryIterator
     this(Query* query, Node* node, uint min, uint max)
     {
         this(query, node);
-        setByteRange(min, max);
+        set_byte_range(min, max);
     }
 
     this(Query* query, Node* node, Point min, Point max)
     {
         this(query, node);
-        setPointRange(min, max);
+        set_point_range(min, max);
     }
 
     ~this()
@@ -64,12 +64,12 @@ struct QueryIterator
         ts_query_cursor_delete(cursor);
     }
 
-    void setByteRange(uint min, uint max)
+    void set_byte_range(uint min, uint max)
     {
         ts_query_cursor_set_byte_range(cursor, min, max);
     }
 
-    void setPointRange(Point min, Point max)
+    void set_point_range(Point min, Point max)
     {
         ts_query_cursor_set_point_range(cursor, min, max);
     }
@@ -152,63 +152,63 @@ struct Query
         return QueryIterator(&this, &node, min, max);
     }
 
-    int patternCount() @nogc nothrow
+    int pattern_count() @nogc nothrow
     {
         return ts_query_pattern_count(tsquery);
     }
 
-    int captureCount() @nogc nothrow
+    int capture_count() @nogc nothrow
     {
         return ts_query_capture_count(tsquery);
     }
 
-    int stringCount() @nogc nothrow
+    int string_count() @nogc nothrow
     {
         return ts_query_string_count(tsquery);
     }
 
-    int startByteForPattern(uint patternId) @nogc nothrow
+    int start_byte_for_pattern(uint patternId) @nogc nothrow
     {
         return ts_query_start_byte_for_pattern(tsquery, patternId);
     }
 
-    const(TSQueryPredicateStep)[] predicatesForPattern(uint patternId) @nogc nothrow
+    const(TSQueryPredicateStep)[] predicates_for_pattern(uint patternId) @nogc nothrow
     {
         uint len;
         auto ptr = ts_query_predicates_for_pattern(tsquery, patternId, &len);
         return ptr[0 .. len];
     }
 
-    bool stepIsDefinite(uint byteOffset) @nogc nothrow
+    bool step_is_definite(uint byteOffset) @nogc nothrow
     {
         return ts_query_step_is_definite(tsquery, byteOffset);
     }
 
-    string captureNameForId(uint captureId) nothrow
+    string capture_name_for_id(uint captureId) nothrow
     {
         uint len;
         auto namePtr = ts_query_capture_name_for_id(tsquery, captureId, &len);
         return namePtr[0 .. len].to!string;
     }
 
-    string captureName(TSQueryCapture capture) nothrow
+    string capture_name(TSQueryCapture capture) nothrow
     {
-        return captureNameForId(capture.index);
+        return capture_name_for_id(capture.index);
     }
 
-    string queryStringValueForId(uint id) nothrow
+    string query_string_value_for_id(uint id) nothrow
     {
         uint len;
         auto namePtr = ts_query_string_value_for_id(tsquery, id, &len);
         return namePtr[0 .. len].to!string;
     }
 
-    void disableCapture(string captureName)
+    void disable_capture(string captureName)
     {
         ts_query_disable_capture(tsquery, captureName.toStringz, captureName.length.to!uint);
     }
 
-    void disablePattern(uint patternId) @nogc nothrow
+    void disable_pattern(uint patternId) @nogc nothrow
     {
         ts_query_disable_pattern(tsquery, patternId);
     }

--- a/src/d_tree_sitter/query.d
+++ b/src/d_tree_sitter/query.d
@@ -8,7 +8,8 @@ import language;
 import node;
 import tree_visitor;
 import other;
-import libc : TSQuery, TSQueryError, TSQueryMatch, TSQueryCursor, TSQueryCapture;
+import libc : TSQuery, TSQueryError, TSQueryMatch, TSQueryCursor,
+    TSQueryCapture, TSQueryPredicateStep;
 
 struct QueryCapture
 {
@@ -26,8 +27,9 @@ struct QueryMatch
 
 struct QueryIterator
 {
-    import libc : ts_query_cursor_new, ts_query_cursor_delete,
-        ts_query_cursor_exec, ts_query_cursor_next_match;
+    import libc : ts_query_cursor_new, ts_query_cursor_delete, ts_query_cursor_exec,
+        ts_query_cursor_next_match, ts_query_cursor_set_byte_range,
+        ts_query_cursor_set_point_range;
 
     Query* query;
     Node* node;
@@ -45,9 +47,31 @@ struct QueryIterator
         ts_query_cursor_exec(cursor, query.tsquery, node.tsnode);
     }
 
+    this(Query* query, Node* node, uint min, uint max)
+    {
+        this(query, node);
+        setByteRange(min, max);
+    }
+
+    this(Query* query, Node* node, Point min, Point max)
+    {
+        this(query, node);
+        setPointRange(min, max);
+    }
+
     ~this()
     {
         ts_query_cursor_delete(cursor);
+    }
+
+    void setByteRange(uint min, uint max)
+    {
+        ts_query_cursor_set_byte_range(cursor, min, max);
+    }
+
+    void setPointRange(Point min, Point max)
+    {
+        ts_query_cursor_set_point_range(cursor, min, max);
     }
 
     int opApply(scope int delegate(QueryMatch) dg)
@@ -79,7 +103,13 @@ class QueryException : Exception
 
 struct Query
 {
-    import libc : ts_query_new, ts_query_delete;
+    import libc : ts_query_new, ts_query_delete, ts_query_pattern_count,
+        ts_query_capture_count, ts_query_start_byte_for_pattern,
+        ts_query_predicates_for_pattern,
+        ts_query_step_is_definite,
+        ts_query_capture_name_for_id,
+        ts_query_disable_capture, ts_query_disable_pattern,
+        ts_query_string_count, ts_query_string_value_for_id;
 
     TSQuery* tsquery;
     Language language;
@@ -112,12 +142,74 @@ struct Query
         return QueryIterator(&this, &node);
     }
 
-    string captureName(TSQueryCapture capture)
+    QueryIterator exec(Node node, uint min, uint max)
     {
-        import libc : ts_query_capture_name_for_id;
+        return QueryIterator(&this, &node, min, max);
+    }
 
-        uint length;
-        auto namePtr = ts_query_capture_name_for_id(tsquery, capture.index, &length);
-        return namePtr[0 .. length].to!string;
+    QueryIterator exec(Node node, Point min, Point max)
+    {
+        return QueryIterator(&this, &node, min, max);
+    }
+
+    int patternCount() @nogc nothrow
+    {
+        return ts_query_pattern_count(tsquery);
+    }
+
+    int captureCount() @nogc nothrow
+    {
+        return ts_query_capture_count(tsquery);
+    }
+
+    int stringCount() @nogc nothrow
+    {
+        return ts_query_string_count(tsquery);
+    }
+
+    int startByteForPattern(uint patternId) @nogc nothrow
+    {
+        return ts_query_start_byte_for_pattern(tsquery, patternId);
+    }
+
+    const(TSQueryPredicateStep)[] predicatesForPattern(uint patternId) @nogc nothrow
+    {
+        uint len;
+        auto ptr = ts_query_predicates_for_pattern(tsquery, patternId, &len);
+        return ptr[0 .. len];
+    }
+
+    bool stepIsDefinite(uint byteOffset) @nogc nothrow
+    {
+        return ts_query_step_is_definite(tsquery, byteOffset);
+    }
+
+    string captureNameForId(uint captureId) nothrow
+    {
+        uint len;
+        auto namePtr = ts_query_capture_name_for_id(tsquery, captureId, &len);
+        return namePtr[0 .. len].to!string;
+    }
+
+    string captureName(TSQueryCapture capture) nothrow
+    {
+        return captureNameForId(capture.index);
+    }
+
+    string queryStringValueForId(uint id) nothrow
+    {
+        uint len;
+        auto namePtr = ts_query_string_value_for_id(tsquery, id, &len);
+        return namePtr[0 .. len].to!string;
+    }
+
+    void disableCapture(string captureName)
+    {
+        ts_query_disable_capture(tsquery, captureName.toStringz, captureName.length.to!uint);
+    }
+
+    void disablePattern(uint patternId) @nogc nothrow
+    {
+        ts_query_disable_pattern(tsquery, patternId);
     }
 }


### PR DESCRIPTION
Adds a `Query` struct for working with the [query API](https://tree-sitter.github.io/tree-sitter/using-parsers#the-query-api), as well as an iterator for traversing matches. 