### PR TITLE
Add parse_to_tree to Parser

### DIFF
--- a/src/d_tree_sitter/parser.d
+++ b/src/d_tree_sitter/parser.d
@@ -228,7 +228,7 @@ struct Parser
   /**
     Parse the given source_code into a Tree
   */
-  Tree parse_to_tree(const string source) {
+  Tree parse_to_tree(const string source) nothrow {
       return Tree(parse(source));
   }
 

--- a/src/d_tree_sitter/parser.d
+++ b/src/d_tree_sitter/parser.d
@@ -226,6 +226,13 @@ struct Parser
   }
 
   /**
+    Parse the given source_code into a Tree
+  */
+  Tree parse_to_tree(const string source) {
+      return Tree(parse(source));
+  }
+
+  /**
         Get the S-expression of the given source code
         Params:
             source_code =     the given source code as a string
@@ -233,7 +240,7 @@ struct Parser
        */
   auto s_expression(const string source_code) nothrow
   {
-    auto tree = Tree(parse(source_code));
+    auto tree = parse_to_tree(source_code);
 
     // Get the root node of the syntax tree.
     auto root_node = tree.root_node();
@@ -247,7 +254,7 @@ struct Parser
   */
   void traverse(const string source_code, TreeVisitor visitor)
   {
-    auto tree = Tree(parse(source_code));
+    auto tree = parse_to_tree(source_code);
 
     // Get the root node of the syntax tree.
     auto root_node = tree.root_node();
@@ -260,7 +267,7 @@ struct Parser
   */
   string traverse_print(const string source_code) @trusted
   {
-    auto tree = Tree(parse(source_code));
+    auto tree = parse_to_tree(source_code);
 
     // Get the root node of the syntax tree.
     auto root_node = tree.root_node();


### PR DESCRIPTION
As I've been working with the Query API I wound up needing a `Tree` for querying. This adds a convenient way to get one. 