### PR TITLE
fix build on archlinux

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -15,7 +15,7 @@ mainSourceFile "./src/d_tree_sitter/d_tree_sitter.d"
 sourceFiles "./src/d_tree_sitter/libc.d" // gen by dpp
 extraDependencyFiles "./src/tree-sitter-version.txt" "./package.json" "./src/meson.build"
 
-lflags "./src/build/libtree_sitter.a"
+lflags "$PACKAGE_DIR/src/d_tree_sitter/build/libtree_sitter.a"
 dependency "bc-string" version="1.2.2"
 
 // -------- Build Options and configurations --------


### PR DESCRIPTION
on archlinux you can build the package fine, but when you reference the package from DUB it fails to find the built library. With this fix it works as expected.